### PR TITLE
Evidence Template + Thor task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Gemfile.lock
 
 # Gem artifacts
 /pkg/
+
+.DS_Store

--- a/lib/dradis/plugins/openvas/gem_version.rb
+++ b/lib/dradis/plugins/openvas/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 1
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/openvas/importer.rb
+++ b/lib/dradis/plugins/openvas/importer.rb
@@ -51,8 +51,8 @@ module Dradis::Plugins::OpenVAS
       # instance-specific evidence though.
       logger.info{ "\t\t => Adding reference to this host" }
 
-      port_info = xml_result.at_xpath('./port').text
-      evidence_content = "\n#[Port]#\n#{port_info}\n\n"
+      # port_info = xml_result.at_xpath('./port').text
+      # evidence_content = "\n#[Port]#\n#{port_info}\n\n"
 
       # There is no way of knowing where OpenVAS is going to place the evidence
       # for each issue. For example:
@@ -91,9 +91,10 @@ module Dradis::Plugins::OpenVAS
       # doesn't provide any per-instance information.
       #
       # Best thing to do is to include the full <description> field and let the user deal with it.
-      description = xml_result.at_xpath('./description').text()
-      evidence_content << "\n#[Description]#\n#{description}\n\n"
-
+      
+      # description = xml_result.at_xpath('./description').text()
+      # evidence_content << "\n#[Description]#\n#{description}\n\n"
+      evidence_content = template_service.process_template(template: 'evidence', data: xml_result)
       content_service.create_evidence(issue: issue, node: host_node, content: evidence_content)
     end
 

--- a/lib/openvas/result.rb
+++ b/lib/openvas/result.rb
@@ -28,7 +28,7 @@ module OpenVAS
         :name, :cvss_base, :risk_factor, :cve, :bid, :xref,
 
         # fields inside :tags
-        :summary, :info_gathered, :insight, :impact, :impact_level, :affected_software, :solution
+        :summary, :info_gathered, :cvss_base_vector, :insight, :impact, :impact_level, :affected_software, :solution
       ]
     end
 

--- a/lib/openvas/result.rb
+++ b/lib/openvas/result.rb
@@ -22,12 +22,12 @@ module OpenVAS
         # NONE
 
         # simple tags
-        :threat, :description, :original_threat, :notes, :overrides,
+        :port, :threat, :description, :original_threat, :notes, :overrides,
 
         # nested tags
         :name, :cvss_base, :risk_factor, :cve, :bid, :xref,
 
-        # fields inside :description
+        # fields inside :tags
         :summary, :info_gathered, :insight, :impact, :impact_level, :affected_software, :solution
       ]
     end

--- a/lib/openvas/v7/result.rb
+++ b/lib/openvas/v7/result.rb
@@ -16,7 +16,7 @@ module OpenVAS::V7
       if @tag_fields.nil?
         delimiters = {
           # Not supported via .fields
-          # 'cvss_base_vector='
+          'cvss_base_vector=' => :cvss_base_vector,
           'impact=' => :impact,
 
           # Not supported via .fields

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -18,13 +18,12 @@ class OpenVASTasks < Thor
     content_service = nil
     template_service = nil
 
+    template_service = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::OpenVAS)
     if defined?(Dradis::Pro)
       detect_and_set_project_scope
       content_service = Dradis::Pro::Plugins::ContentService.new(plugin: Dradis::Plugins::OpenVAS)
-      template_service = Dradis::Pro::Plugins::TemplateService.new(plugin: Dradis::Plugins::OpenVAS)
     else
       content_service = Dradis::Plugins::ContentService.new(plugin: Dradis::Plugins::OpenVAS)
-      template_service = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::OpenVAS)
     end
 
     importer = Dradis::Plugins::OpenVAS::Importer.new(

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -1,0 +1,2 @@
+evidence.port
+evidence.description

--- a/templates/evidence.sample
+++ b/templates/evidence.sample
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<result id="e2ccf551-ea4e-4186-9b24-76287d6244f3">
+  <subnet>172.31.253.9</subnet>
+  <host>172.31.253.9</host>
+  <port>general/tcp</port>
+  <nvt oid="1.3.6.1.4.1.25623.1.0.802610">
+    <name>Oracle Java SE JRE Multiple Vulnerabilities - February 2012 (Windows - 01)</name>
+    <cvss_base>10.0</cvss_base>
+    <risk_factor>Critical</risk_factor>
+    <cve>CVE-2011-3563, CVE-2012-0499, CVE-2012-0502, CVE-2012-0503, CVE-2012-0505, CVE-2012-0506</cve>
+    <bid>52011, 52012, 52014, 52016, 52017, 52018</bid>
+    <xref>URL:http://secunia.com/advisories/48009, URL:http://www.pre-cert.de/advisories/PRE-SA-2012-01.txt, URL:http://www.oracle.com/technetwork/topics/security/javacpufeb2012-366318.html, URL:http://www.oracle.com/technetwork/java/javase/documentation/overview-142120.html, URL:http://www.oracle.com/technetwork/java/javase/documentation/overview-137139.html</xref>
+  </nvt>
+  <threat>High</threat>
+  <description>
+  Summary:
+  This host is installed with Oracle Java SE JRE and is prone to
+  multiple vulnerabilities.
+
+  Vulnerability Insight:
+  Multiple flaws are caused by unspecified errors in the following
+  components:
+  - 2D
+  - AWT
+  - Sound
+  - I18n
+  - CORBA
+  - Serialization
+
+  Impact:
+  Successful exploitation allows remote attackers to affect confidentiality,
+  integrity, and availability via unknown vectors.
+
+  Impact Level: System/Application
+
+  Affected Software/OS:
+  Oracle Java SE JRE 7 Update 2 and earlier, 6 Update 30 and earlier, 5.0 Update 33
+  and earlier, and 1.4.2_35 and earlier
+
+  Solution:
+  Upgrade to Oracle Java SE JRE versions 7 Update 3, 6 Update 31, 5.0 Update
+  34, 1.4.2_36 or later. For updates refer to
+  http://www.oracle.com/technetwork/topics/security/javacpufeb2012-366318.html
+</description>
+  <original_threat>High</original_threat>
+  <notes/>
+  <overrides/>
+</result>

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,0 +1,6 @@
+#[Port]#
+%evidence.port%
+
+
+#[Description]#
+%evidence.description%

--- a/templates/result.fields
+++ b/templates/result.fields
@@ -5,6 +5,7 @@ result.notes
 result.overrides
 result.name
 result.cvss_base
+result.cvss_base_vector
 result.risk_factor
 result.cve
 result.bid

--- a/templates/result.template
+++ b/templates/result.template
@@ -16,14 +16,10 @@
 
 
 #[References]#
-CVE
-%result.cve%
-
-BID
-%result.bid%
-
-Other
-%result.xref%
+CVE: %result.cve%
+CVSS Vector: %cvss_base_vector%
+BID: %result.bid%
+Other: %result.xref%
 
 
 #[RawDescription]#


### PR DESCRIPTION
This PR adds a separate Evidence template for OpenVAS uploads and resolves an error with Thor in the Pro edition. 

Uploading an OpenVAS file in the command line on the Pro edition (through the Thor task) currently throws the following error: 

`uninitialized constant Dradis::Pro::Plugins::TemplateService (NameError)`

This fix resolves the error and also increases the tiny version number for the add-on