### PR TITLE
Move and add fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Dradis Framework 3.8 (September, 2017) ##
+## Dradis Framework 3.8 (XXXX, 2017) ##
+*  Move `threat` and `severity` available fields to the Evidence level to
+   accomodate changing values
 
-*   No changes.
+*  Add `results.vuldetect` as an available field
 
 ## Dradis Framework 3.7 (Jul, 2017) ##
 

--- a/dradis-openvas.gemspec
+++ b/dradis-openvas.gemspec
@@ -26,7 +26,10 @@ Gem::Specification.new do |spec|
   # until we bump Dradis Pro to 4.1.
   # s.add_dependency 'rails', '~> 4.1.1'
   spec.add_dependency 'dradis-plugins', '~> 3.6'
+  spec.add_dependency 'nokogiri', '~> 1.3'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec-rails'
+  spec.add_development_dependency 'combustion', '~> 0.5.2'
 end

--- a/lib/dradis/plugins/openvas/gem_version.rb
+++ b/lib/dradis/plugins/openvas/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 8
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/openvas/result.rb
+++ b/lib/openvas/result.rb
@@ -22,7 +22,7 @@ module OpenVAS
         # NONE
 
         # simple tags
-        :port, :threat, :description, :original_threat, :notes, :overrides,
+        :port, :threat, :severity, :description, :original_threat, :original_severity, :notes, :overrides,
 
         # nested tags
         :name, :cvss_base, :risk_factor, :cve, :bid, :xref,

--- a/lib/openvas/result.rb
+++ b/lib/openvas/result.rb
@@ -28,7 +28,7 @@ module OpenVAS
         :name, :cvss_base, :risk_factor, :cve, :bid, :xref,
 
         # fields inside :tags
-        :summary, :info_gathered, :cvss_base_vector, :insight, :impact, :impact_level, :affected_software, :solution
+        :summary, :info_gathered, :cvss_base_vector, :vuldetect, :insight, :impact, :impact_level, :affected_software, :solution
       ]
     end
 

--- a/lib/openvas/result.rb
+++ b/lib/openvas/result.rb
@@ -22,13 +22,13 @@ module OpenVAS
         # NONE
 
         # simple tags
-        :port, :threat, :severity, :description, :original_threat, :original_severity, :notes, :overrides,
+        :description, :notes, :original_threat, :original_severity, :overrides, :port, :severity, :threat,
 
         # nested tags
-        :name, :cvss_base, :risk_factor, :cve, :bid, :xref,
+        :bid, :cve, :cvss_base, :name, :risk_factor, :xref,
 
         # fields inside :tags
-        :summary, :info_gathered, :cvss_base_vector, :vuldetect, :insight, :impact, :impact_level, :affected_software, :solution
+        :affected_software, :cvss_base_vector, :impact, :impact_level, :info_gathered, :insight, :solution, :summary, :vuldetect
       ]
     end
 

--- a/lib/openvas/v7/result.rb
+++ b/lib/openvas/v7/result.rb
@@ -20,7 +20,7 @@ module OpenVAS::V7
           'impact=' => :impact,
 
           # Not supported via .fields
-          # 'vuldetect='
+          'vuldetect=' => :vuldetect,
           'insight=' => :insight,
           'solution=' => :solution,
           'summary=' => :summary,

--- a/spec/openvas/result_spec.rb
+++ b/spec/openvas/result_spec.rb
@@ -1,35 +1,61 @@
 require 'spec_helper'
 
-describe Openvas::Result do
-  include FixtureLoader
+  describe 'OpenVAS upload plugin' do
+    before(:each) do
+      # Stub template service
+      templates_dir = File.expand_path('../../../templates', __FILE__)
+      expect_any_instance_of(Dradis::Plugins::TemplateService)
+      .to receive(:default_templates_dir).and_return(templates_dir)
 
-  it "splits the <description> tag in its component fields" do
-    xml_doc = load_fixture_file('result.xml')
-    result = Openvas::Result.new( xml_doc.at_xpath('/result') )
-    result.description.should eq(xml_doc.at_xpath('/result/description').text)
+      # Init services
+      plugin = Dradis::Plugins::OpenVAS
 
-    expect(result.summary).to eq("This host is installed with Oracle Java SE JRE and is prone to\nmultiple vulnerabilities.\n\n")
-    expect(result.insight).to eq("Multiple flaws are caused by unspecified errors in the following\ncomponents:\n- 2D\n- AWT\n- Sound\n- I18n\n- CORBA\n- Serialization\n\n")
+      @content_service = Dradis::Plugins::ContentService::Base.new(
+        logger: Logger.new(STDOUT),
+        plugin: plugin
+      )
+
+      @importer = Dradis::Plugins::OpenVAS::Importer.new(
+        content_service: @content_service
+      )
+
+      # Stub dradis-plugins methods
+      #
+      # They return their argument hashes as objects mimicking
+      # Nodes, Issues, etc
+      allow(@content_service).to receive(:create_node) do |args|
+        obj = OpenStruct.new(args)
+        obj.define_singleton_method(:set_property) { |_, __| }
+        obj
+      end
+      allow(@content_service).to receive(:create_issue) do |args|
+        OpenStruct.new(args)
+      end
+      allow(@content_service).to receive(:create_evidence) do |args|
+        OpenStruct.new(args)
+      end
+    end
+
+    it "creates issues and evidence as expected" do
+      # splits the <tags> into the correct component fields
+      # respects paragraphs within the component fields of <tags>
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("#[Title]#\nOpenSSL CCS Man in the Middle Security Bypass Vulnerability")
+        expect(args[:text]).to include("#[Description]#\nOpenSSL is prone to security-bypass vulnerability.")
+        expect(args[:text]).to include("#[Recommendation]#\nUpdates are available.")
+        expect(args[:text]).to include("#[Insight]#\nOpenSSL does not properly restrict processing of ChangeCipherSpec\nmessages, which allows man-in-the-middle attackers to trigger use of a\nzero-length master key in certain OpenSSL-to-OpenSSL communications, and\nconsequently hijack sessions or obtain sensitive information, via a crafted\nTLS handshake, aka the 'CCS Injection' vulnerability.")
+        expect(args[:text]).to include("#[Detection]#\nSend two SSL ChangeCipherSpec request and check the response.")
+        OpenStruct.new(args)
+      end
+      # pulls threat and severity down to the Evidence level
+      expect(@content_service).to receive(:create_evidence) do |args|
+        expect(args[:content]).to include("#[Threat]#\nMedium")
+        expect(args[:content]).to include("#[Severity]#\n6.8")
+        expect(args[:issue].text).to include("#[Title]#\nOpenSSL CCS Man in the Middle Security Bypass Vulnerability")
+        expect(args[:node].label).to eq("10.10.10.10")
+      end
+
+      @importer.import(file: 'spec/fixtures/files/v7/report_v7.xml')
+    end
+
   end
-
-  it "respects paragraphs within the component fields of the <description> value" do
-    xml_doc = load_fixture_file('result2.xml')
-    result = Openvas::Result.new( xml_doc.at_xpath('/result') )
-    result.summary.should eq("A weakness has been discovered in Apache web servers that are\nconfigured to use the FileETag directive. Due to the way in which\nApache generates ETag response headers, it may be possible for an\nattacker to obtain sensitive information regarding server files.\nSpecifically, ETag header fields returned to a client contain the\nfile's inode number.\n\nExploitation of this issue may provide an attacker with information\nthat may be used to launch further attacks against a target network.\n\nOpenBSD has released a patch that addresses this issue. Inode numbers\nreturned from the server are now encoded using a private hash to avoid\nthe release of sensitive information.\n")
-  end
-
-  it "correctly parses the fringe 'Impact Level' case" do
-    xml_doc = load_fixture_file('result.xml')
-    result = Openvas::Result.new( xml_doc.at_xpath('/result') )
-
-    result.impact_level.should eq('System/Application')
-  end
-
-
-  it "correctly parses the last component field in the <description>" do
-    xml_doc = load_fixture_file('result2.xml')
-    result = Openvas::Result.new( xml_doc.at_xpath('/result') )
-
-    result.info_gathered.should eq("Inode: 1050855\nSize: 177\n\n")
-  end
-end

--- a/spec/openvas/result_spec.rb
+++ b/spec/openvas/result_spec.rb
@@ -15,7 +15,7 @@ require 'spec_helper'
         plugin: plugin
       )
 
-      @importer = Dradis::Plugins::OpenVAS::Importer.new(
+      @importer = plugin::Importer.new(
         content_service: @content_service
       )
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,35 +1,9 @@
-ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path("../../../../../config/environment", __FILE__)
-require 'rspec/rails'
+require 'rubygems'
+require 'bundler/setup'
+require 'nokogiri'
+require 'combustion'
 
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-require 'support/fixture_loader'
+Combustion.initialize!
 
 RSpec.configure do |config|
-  # CLI niceties
-  config.order = :random
-
-  # Filter which specs to run
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.filter_run :focus => true
-  config.run_all_when_everything_filtered = true
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = false
-
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
-  end
 end

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -1,2 +1,6 @@
+evidence.threat
+evidence.original_threat
+evidence.severity
+evidence.original_severity
 evidence.port
 evidence.description

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,6 +1,11 @@
 #[Port]#
 %evidence.port%
 
+#[Threat]#
+%evidence.threat%
+
+#[Severity]#
+%evidence.severity%
 
 #[Description]#
 %evidence.description%

--- a/templates/result.fields
+++ b/templates/result.fields
@@ -1,6 +1,3 @@
-result.threat
-result.description
-result.original_threat
 result.notes
 result.overrides
 result.name

--- a/templates/result.fields
+++ b/templates/result.fields
@@ -8,6 +8,7 @@ result.cve
 result.bid
 result.xref
 result.summary
+result.vuldetect
 result.insight
 result.info_gathered
 result.impact

--- a/templates/result.template
+++ b/templates/result.template
@@ -7,11 +7,17 @@
 #[Description]#
 %result.summary%
 
+#[Insight]#
+%result.insight%
+
+#[Detection]#
+%result.vuldetect%
+
 #[Recommendation]#
 %result.solution%
 
 #[References]#
 CVE: %result.cve%
-CVSS Vector: %cvss_base_vector%
+CVSS Vector: %result.cvss_base_vector%
 BID: %result.bid%
 Other: %result.xref%

--- a/templates/result.template
+++ b/templates/result.template
@@ -1,12 +1,8 @@
 #[Title]#
 %result.name%
 
-
-#[CVSSv2]#
+#[CVSS]#
 %result.cvss_base%
-
-#[AffectedSoftware]#
-%result.affected_software%
 
 #[Description]#
 %result.summary%
@@ -14,14 +10,8 @@
 #[Recommendation]#
 %result.solution%
 
-
 #[References]#
 CVE: %result.cve%
 CVSS Vector: %cvss_base_vector%
 BID: %result.bid%
 Other: %result.xref%
-
-
-#[RawDescription]#
-(note that some of the information below can change from instance to instance of this problem)
-%result.description%


### PR DESCRIPTION
The PR does the following: 

- Resolves problems with `severity` and `threat` levels that change from one `<result>` to another in the OpenVAS XML by moving `severity` and `threat` down to the Evidence level
- Adds `result.vuldetect` as an available field (pulled out of the tags: https://github.com/dradis/dradis-openvas/blob/master/spec/fixtures/files/v7/report_v7.xml#L117)

