### PR TITLE
Update Node label parsing for hostname tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.3.0 (XXXX 2022)
+  - Update Node label parsing so that `<hostname>` tags don't cause problems
+
 v4.2.0 (February 2022)
   - No changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 v4.3.0 (XXXX 2022)
-  - Update Node label parsing so that `<hostname>` tags don't cause problems
+  - Update Node label parsing. Include :hostname and :asset_id properties.
 
 v4.2.0 (February 2022)
   - No changes

--- a/lib/dradis/plugins/openvas/gem_version.rb
+++ b/lib/dradis/plugins/openvas/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 2
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/openvas/importer.rb
+++ b/lib/dradis/plugins/openvas/importer.rb
@@ -35,7 +35,7 @@ module Dradis::Plugins::OpenVAS
 
     def process_result(xml_result)
       # Extract host
-      host_label = xml_result.at_xpath('./host').text()
+      host_label = xml_result.at_xpath('./host/text()').to_s
       self.host_node = content_service.create_node(label: host_label, type: :host)
 
       # Uniquely identify this issue

--- a/lib/dradis/plugins/openvas/importer.rb
+++ b/lib/dradis/plugins/openvas/importer.rb
@@ -35,8 +35,7 @@ module Dradis::Plugins::OpenVAS
 
     def process_result(xml_result)
       # Extract host
-      host_label = xml_result.at_xpath('./host/text()').to_s
-      self.host_node = content_service.create_node(label: host_label, type: :host)
+      set_host(xml_result.at_xpath('./host'))
 
       # Uniquely identify this issue
       nvt_oid = xml_result.at_xpath('./nvt')[:oid]
@@ -91,6 +90,19 @@ module Dradis::Plugins::OpenVAS
       
       evidence_content = template_service.process_template(template: 'evidence', data: xml_result)
       content_service.create_evidence(issue: issue, node: host_node, content: evidence_content)
+    end
+
+    def set_host(xml_host)
+      host_label = xml_host.at_xpath('text()').text
+      self.host_node = content_service.create_node(label: host_label, type: :host)
+
+      xml_hostname = xml_host.at_xpath('./hostname')
+      host_node.set_property(:hostname, xml_hostname.text) if xml_hostname
+
+      xml_asset = xml_host.at_xpath('./asset')
+      host_node.set_property(:asset_id, xml_asset[:asset_id]) if xml_asset
+
+      host_node.save!
     end
 
   end

--- a/spec/fixtures/files/report_v24.xml
+++ b/spec/fixtures/files/report_v24.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report id="9917b2e8-7db6-475b-b591-bd3ba828625c">
+   <report>
+      <results>
+         <result id="32249f6c-89f1-4a93-888f-29404b01374f">
+            <subnet>188.111.11.85</subnet>
+            <host>188.111.11.85<hostname>www.google.com</hostname></host>
+            <port>http (80/tcp)</port>
+            <nvt oid="1.3.6.1.4.1.25623.1.0.103122">
+               <name>Apache Web Server ETag Header Information Disclosure Weakness</name>
+               <family>Web application abuses</family>
+               <cvss_base>4.3</cvss_base>
+               <risk_factor>Medium</risk_factor>
+               <cve>CVE-2003-1418</cve>
+               <bid>6939</bid>
+               <tags>cvss_base_vector=AV:N/AC:M/Au:N/C:P/I:N/A:N|summary=A weakness has been discovered in Apache web servers that are
+configured to use the FileETag directive. Due to the way in which
+Apache generates ETag response headers, it may be possible for an
+attacker to obtain sensitive information regarding server files.
+Specifically, ETag header fields returned to a client contain the
+file's inode number.
+
+Exploitation of this issue may provide an attacker with information
+that may be used to launch further attacks against a target network.
+
+OpenBSD has released a patch that addresses this issue. Inode numbers
+returned from the server are now encoded using a private hash to avoid
+the release of sensitive information.|solution=OpenBSD has released a patch to address this issue.
+
+Novell has released TID10090670 to advise users to apply the available
+workaround of disabling the directive in the configuration file for
+Apache releases on NetWare. Please see the attached Technical
+Information Document for further details.</tags>
+               <cert>
+                  <warning>database not available</warning>
+               </cert>
+               <xref>URL:https://www.securityfocus.com/bid/6939, URL:http://httpd.apache.org/docs/mod/core.html#fileetag, URL:http://www.openbsd.org/errata32.html, URL:http://support.novell.com/docs/Tids/Solutions/10090670.html</xref>
+            </nvt>
+            <threat>Medium</threat>
+            <description>Summary:
+ A weakness has been discovered in Apache web servers that are
+configured to use the FileETag directive. Due to the way in which
+Apache generates ETag response headers, it may be possible for an
+attacker to obtain sensitive information regarding server files.
+Specifically, ETag header fields returned to a client contain the
+file's inode number.
+
+Exploitation of this issue may provide an attacker with information
+that may be used to launch further attacks against a target network.
+
+OpenBSD has released a patch that addresses this issue. Inode numbers
+returned from the server are now encoded using a private hash to avoid
+the release of sensitive information.
+ Solution:
+ OpenBSD has released a patch to address this issue.
+
+Novell has released TID10090670 to advise users to apply the available
+workaround of disabling the directive in the configuration file for
+Apache releases on NetWare. Please see the attached Technical
+Information Document for further details.
+
+Information that was gathered:
+Inode: 1050855
+Size: 177</description>
+            <original_threat>Medium</original_threat>
+            <notes />
+            <overrides />
+         </result>
+      </results>
+   </report>
+</report>

--- a/spec/openvas/upload_v24_spec.rb
+++ b/spec/openvas/upload_v24_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'byebug'
+
 describe 'Openvas upload plugin' do
   describe 'importer' do
     before(:each) do

--- a/spec/openvas/upload_v24_spec.rb
+++ b/spec/openvas/upload_v24_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'byebug'
+describe 'Openvas upload plugin' do
+  describe 'importer' do
+    before(:each) do
+      # Stub template service
+      templates_dir = File.expand_path('../../../templates', __FILE__)
+      expect_any_instance_of(Dradis::Plugins::TemplateService)
+      .to receive(:default_templates_dir).and_return(templates_dir)
+
+      plugin = Dradis::Plugins::OpenVAS
+
+      @content_service = Dradis::Plugins::ContentService::Base.new(plugin: plugin)
+
+      allow(@content_service).to receive(:create_note) do |args|
+        OpenStruct.new(args)
+      end
+      allow(@content_service).to receive(:create_node) do |args|
+        OpenStruct.new(args)
+      end
+      allow(@content_service).to receive(:create_issue) do |args|
+        OpenStruct.new(args)
+      end
+      allow(@content_service).to receive(:create_evidence) do |args|
+        OpenStruct.new(args)
+      end
+
+      @importer = plugin::Importer.new(
+        content_service: @content_service
+      )
+    end
+
+    context 'Openvas v24 output' do
+      it 'parses node label without hostname' do
+        expect(@content_service).to receive(:create_node) do |args|
+          expect(args[:label]).to eq('188.111.11.85')
+          expect(args[:type]).to eq(:host)
+        end
+
+        @importer.import(file: File.expand_path('../fixtures/files/report_v24.xml', __dir__))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary
In previous versions of OpenVAS, the host tag appeared like: 
```
<host>10.0.0.1</host>
```
But, in OpenVAS v24, the host tag looks like:
```
<host>10.0.0.1<asset asset_id="123-456-7890-000-000"></asset><hostname>scanme.com</hostname></host>
```
This was causing the Node labels to come into Dradis as `10.0.0.1scanme.com` rather than the expected `10.0.0.1`. 

This PR updates the Node label parsing so that only the IP is pulled in, regardless of whether the hostname is present or not. 

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.